### PR TITLE
Added support for requirement enemies 'ALL'

### DIFF
--- a/Major.java
+++ b/Major.java
@@ -254,6 +254,10 @@ public class Major {
 	 * 		-----> R3 and R5 are enemies, R4 and R5 are enemies, but R3 and R4 are friends.
 	 * R4:4
 	 * R5:3
+	 * R1:ALL----> If the string "ALL" is found, this requirement will be made a loner.
+	 * 		-----> Loners are enemies with all other requirements (including from other majors)
+	 * 		-----> except for those specified here.
+	 * R1:R2 ----> In this example, R1 is enemies with every requirement other than R2.
 	 * 
 	 * 
 	 * 
@@ -331,8 +335,10 @@ public class Major {
 	/**
 	 * Given a line of the form "R3: R1, R2, R7 "
 	 *  or  "R3: 5"
-	 *  the former means to make r1, r2, and r7 enemies of r3.
-	 *   the latter means to put r3 in friend group 5
+	 *  or "R3: ALL"
+	 *  the first means to make r1, r2, and r7 enemies of r3.
+	 *   the middle means to put r3 in friend group 5
+	 *   the third means to make r3 a loner, so it is enemies with all requirements
 	 *   
 	 * @param s
 	 */
@@ -347,6 +353,9 @@ public class Major {
 			}
 		}
 		else{
+			if(split[1].toUpperCase().equals("ALL")){
+				RequirementGraph.makeLoner(this.reqList.get(firstReqNum));
+			}
 			reqFriendGroups.set(firstReqNum,Integer.parseInt(split[1]));
 		}
 	}

--- a/RequirementGraph.java
+++ b/RequirementGraph.java
@@ -21,6 +21,7 @@ public class RequirementGraph {
 	//We will use the edge list format for storing this graph, because
 	// it will probably be sparse.
 	static Hashtable<Requirement, HashSet<Requirement>> edges = new Hashtable<Requirement, HashSet<Requirement>>();
+	static HashSet<Requirement> loners = new HashSet<Requirement>();
 	
 	/**
 	 * Declares that r1 can't play nice with r2.
@@ -45,18 +46,34 @@ public class RequirementGraph {
 	}
 	
 	/**
+	 * Set it so that this requirement is enemies with all other requirements,
+	 * except 
+	 * @param r
+	 */
+	public static void makeLoner(Requirement r){
+		loners.add(r);
+	}
+	
+	public static boolean isLoner(Requirement r){
+		return loners.contains(r);
+	}
+	
+	/**
 	 * Check if r1 and r2 can share a course or not
 	 */
 	public static boolean doesPlayNice(Requirement r1, Requirement r2){
-		
+		boolean result = true;
+		if(isLoner(r1) || isLoner(r2)){
+			result = !result;
+		}
 		HashSet<Requirement> outEdges = edges.get(r1);
 		if(outEdges == null){
-			return true;
+			return result;
 		}
 		if(outEdges.contains(r2)){
-			return false;
+			return !result;
 		}
-		return true;
+		return result;
 	}
 	
 	/**


### PR DESCRIPTION
In a major file, a requirement may be declared to be enemies with all requirements. This makes it a loner, and edges in the requirement graph mean friends now rather than enemies